### PR TITLE
Added the ability to use environment variable for configuration.

### DIFF
--- a/lib/config.rb
+++ b/lib/config.rb
@@ -26,12 +26,12 @@ module PaypalAdaptive
     end
 
     def load(rails_env)
-      config= YAML.load_file(@config_filepath)[rails_env]
+      config= YAML.load_file(@config_filepath)[rails_env] || {}
 
       if config["retain_requests_for_test"] == true
         @retain_requests_for_test = true
       else
-        pp_env = config['environment'].to_sym
+        pp_env = (config['environment'] || ENV['PAYPAL_ADAPTIVE_ENVIRONMENT']).to_sym
 
         @paypal_base_url = PAYPAL_BASE_URL_MAPPING[pp_env]
         @api_base_url = API_BASE_URL_MAPPING[pp_env]


### PR DESCRIPTION
I wanted to be able to deploy my application on Heroku and would prefer to keep production paypal information out of the the configuration files (for deployments and my git repository). 

I've added the ability to set environment configurations. 

export PAYPAL_ADAPTIVE_USERNAME='some@email.com'
export PAYPAL_ADAPTIVE_PASSWORD='1234567890'
export PAYPAL_ADAPTIVE_SIGNATURE='SomeSignature'
export PAYPAL_ADAPTIVE_APPLICATION_ID='APP-XXXXXXXXXXXXXXXX'
export PAYPAL_ADAPTIVE_ENVIRONMENT='production'

The configuration file still works and takes precedence over the environment variables. 

Thanks for your helpful gem.
Aaron.
