### PR TITLE
Support for ERB templates in paypal_adaptive.yml

### DIFF
--- a/config/paypal_adaptive.yml
+++ b/config/paypal_adaptive.yml
@@ -21,3 +21,11 @@ production:
   signature: "my_production_signature"
   application_id: "my_production_app_id"
   ssl_cert_file:
+
+with_erb_tags:
+  environment: "sandbox"
+  username: <%= ENV['paypal.username'] %>
+  password: <%= ENV['paypal.password'] %>
+  signature: "signupforuseratsandboxpaypal"
+  application_id: "APP-TEST"
+  ssl_cert_file:

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -1,4 +1,5 @@
 require 'yaml'
+require 'erb'
 
 module PaypalAdaptive
   class Config
@@ -27,8 +28,8 @@ module PaypalAdaptive
       end
     end
 
-    def load(rails_env, config_override)
-      config = YAML.load_file(@config_filepath)[rails_env]
+    def load(environment, config_override)
+      config = YAML.load(ERB.new(File.new(@config_filepath).read).result)[environment]
       config.merge!(config_override) unless config_override.nil?
 
       if config["retain_requests_for_test"] == true

--- a/test/unit/config_test.rb
+++ b/test/unit/config_test.rb
@@ -12,4 +12,13 @@ class ConfigTest < Test::Unit::TestCase
     assert File.exists?(@config.ssl_cert_file)
     assert_equal nil, @config.ssl_cert_path
   end
+
+  def test_erb_tags
+    ENV['paypal.username'] = 'account@email.com'
+    ENV['paypal.password'] = 's3krit'
+    
+    config = PaypalAdaptive::Config.new("with_erb_tags")
+    assert_equal 'account@email.com', config.headers["X-PAYPAL-SECURITY-USERID"]
+    assert_equal 's3krit', config.headers["X-PAYPAL-SECURITY-PASSWORD"]
+  end
 end


### PR DESCRIPTION
A possibility to write the following in paypal_adaptive.yml:

``` yaml
production:
  environment: "production"
  username: <%= ENV['PAYPAL_USERNAME'] %>
  password: <%= ENV['PAYPAL_PASSWORD'] %>
  signature:  <%= ENV['PAYPAL_SIGNATURE'] %>
  application_id: <%= ENV['PAYPAL_APPLICATION_ID'] %>
```

Essential if production server is deployed on Heroku.
