### PR TITLE
Adding support for embedded payments

### DIFF
--- a/lib/paypal_adaptive/response.rb
+++ b/lib/paypal_adaptive/response.rb
@@ -27,8 +27,14 @@ module PaypalAdaptive
       end
     end
 
-    def approve_paypal_payment_url
-      self['payKey'].nil? ? nil : "#{@@paypal_base_url}/webscr?cmd=_ap-payment&paykey=#{self['payKey']}"
+    def approve_paypal_payment_url(type=nil)
+      if self['payKey'].nil?
+        return nil
+      elsif ['mini', 'embedded'].include?(type.to_s)
+        return "#{@@paypal_base_url}/webapps/adaptivepayment/flow/pay?expType=#{type.to_s}&paykey=#{self['payKey']}"
+      end
+      
+      "#{@@paypal_base_url}/webscr?cmd=_ap-payment&paykey=#{self['payKey']}"
     end
 
     def preapproval_paypal_payment_url


### PR DESCRIPTION
Hi Tommy,

I made a simple change in the response.rb file so that the gem can now support embedded payments through lightbox or minibrowser.

For the embedded payments to work properly it's necessary to use the PayPal javascript libraries, according to the Adaptive Payments Developer Guide.

This pull request is related to your issue #20 by gabecoyne.
