### PR TITLE
Little fix on embedded payments support

### DIFF
--- a/lib/paypal_adaptive/response.rb
+++ b/lib/paypal_adaptive/response.rb
@@ -30,7 +30,7 @@ module PaypalAdaptive
     def approve_paypal_payment_url(type=nil)
       if self['payKey'].nil?
         return nil
-      elsif ['mini', 'embedded'].include?(type.to_s)
+      elsif ['mini', 'light'].include?(type.to_s)
         return "#{@@paypal_base_url}/webapps/adaptivepayment/flow/pay?expType=#{type.to_s}&paykey=#{self['payKey']}"
       end
       


### PR DESCRIPTION
Hi Tommy,

I'm sending another pull request related to the issue #21 you closed a while ago.
This pull request corrects a little mistake I made on the previous one.

The expType parameter (the embedded payment experience type) send to PayPal can be either "mini" or "light" and on my previous pull request I used ''embedded" instead of "light".

Even though the embedded payment is working correctly with "embedded", this pull request makes the generated URL exactly as expected by PayPal.
