### PR TITLE
Failed pre-approval payment requests are not successful

### DIFF
--- a/lib/paypal_adaptive/response.rb
+++ b/lib/paypal_adaptive/response.rb
@@ -8,7 +8,8 @@ module PaypalAdaptive
     end
     
     def success?
-      self['responseEnvelope']['ack'] == 'Success'
+      self['responseEnvelope']['ack'].to_s =~ /^Success$/i &&
+        !(self['paymentExecStatus'].to_s =~ /^ERROR$/i)
     end
     
     def errors

--- a/test/data/invalid_preapproval_error_execstatus.json
+++ b/test/data/invalid_preapproval_error_execstatus.json
@@ -1,0 +1,22 @@
+{
+  "responseEnvelope":{
+    "timestamp":"2011-11-20T09:33:51.178-08:00",
+    "ack":"Success",
+    "correlationId":"XXXXX",
+    "build":"2279004"
+  },
+  "payKey":"AP-XXXXXXXXXXXXXXXXX",
+  "paymentExecStatus":"ERROR",
+  "payErrorList":{
+    "payError":[{
+      "receiver":{"amount":"25.0","email":"email@email.com"},
+      "error":{
+        "errorId":"580036",
+        "domain":"PLATFORM",
+        "severity":"Error",
+        "category":"Application",
+        "message":"This transaction cannot be processed. Please enter a valid credit card number and type"
+      }
+    }]
+  }
+}

--- a/test/unit/preapproval_test.rb
+++ b/test/unit/preapproval_test.rb
@@ -36,6 +36,18 @@ class PreapprovalTest < Test::Unit::TestCase
     assert_nil pp_response['preapprovalKey']
   end
 
+  def test_invalid_preapproval_with_bad_credit_information
+    puts "-------"
+    puts "invalid"
+    data_filepath =  File.join(File.dirname(__FILE__),"..", "data","invalid_preapproval_error_execstatus.json")
+
+    data = read_json_file(data_filepath)
+    pp_response = @preapproval_request.preapproval(data)
+    puts "error message is #{pp_response.error_message}"
+
+    assert pp_response.success? == false
+  end
+
   def read_json_file(filepath)
     File.open(filepath, "rb"){|f| JSON.parse(f.read)}
   end


### PR DESCRIPTION
Preapproval-based payment requests are incorrectly being reported as successful transactions (see issue #25).  This checks not only the `ack` response, but also checks the optional `paymentExecStatus` value, as well.
