### PR TITLE
PaypalAdaptive is broken under Ruby 1.9.3

### DIFF
--- a/lib/paypal_adaptive/ipn_notification.rb
+++ b/lib/paypal_adaptive/ipn_notification.rb
@@ -23,7 +23,7 @@ module PaypalAdaptive
       http.ca_file = @@ssl_cert_file unless @@ssl_cert_file.nil?
       
       path = "#{@@paypal_base_url}/cgi-bin/webscr"
-      resp, response_data = http.post(path, data)
+      response_data = http.post(path, data).body
       
       @verified = response_data == "VERIFIED"
     end

--- a/lib/paypal_adaptive/request.rb
+++ b/lib/paypal_adaptive/request.rb
@@ -85,7 +85,7 @@ module PaypalAdaptive
       http.ca_path = @@ssl_cert_path unless @@ssl_cert_path.nil?
       http.ca_file = @@ssl_cert_file unless @@ssl_cert_file.nil?
 
-      resp, response_data = http.post(path, api_request_data, @@headers)
+      response_data = http.post(path, api_request_data, @@headers).body
 
       JSON.parse(response_data)
     end


### PR DESCRIPTION
It works also fine under Ruby 1.8.7 and 1.9.2. (1.8.6 and 1.9.1 wasn't be tested)
