### PR TITLE
fix fatal in http.rb because of the call to strip on a Fixnum

### DIFF
--- a/lib/paypal_adaptive/config.rb
+++ b/lib/paypal_adaptive/config.rb
@@ -44,7 +44,7 @@ module PaypalAdaptive
         @api_base_url = API_BASE_URL_MAPPING[pp_env]
         
         # http.rb requires headers to be strings. Protect against ints in paypal_adaptive.yml
-        config.update(config)){ |key,v| v.to_s }
+        config.update(config){ |key,v| v.to_s }
         @headers = {
           "X-PAYPAL-SECURITY-USERID" => config['username'],
           "X-PAYPAL-SECURITY-PASSWORD" => config['password'],


### PR DESCRIPTION
http.rb expects header values to all be strings. Having a password in paypal_adaptive.yml that is only numeric vs alphanumeric and forgetting to use quotes causes the following frustrating, confusing fatal in http.rb

undefined method `strip' for [my password as a number]:Fixnum
Rails.root: /Users/ryan/dev/auction

/Users/ryan/.rvm/rubies/ruby-1.9.3-p0/lib/ruby/1.9.1/net/http.rb:1435:in `block in initialize_http_header'
/Users/ryan/.rvm/rubies/ruby-1.9.3-p0/lib/ruby/1.9.1/net/http.rb:1433:in`each'
/Users/ryan/.rvm/rubies/ruby-1.9.3-p0/lib/ruby/1.9.1/net/http.rb:1433:in `initialize_http_header'
/Users/ryan/.rvm/rubies/ruby-1.9.3-p0/lib/ruby/1.9.1/net/http.rb:1862:in`initialize'
/Users/ryan/.rvm/rubies/ruby-1.9.3-p0/lib/ruby/1.9.1/net/http.rb:2093:in `initialize'
/Users/ryan/.rvm/rubies/ruby-1.9.3-p0/lib/ruby/1.9.1/net/http.rb:1307:in`new'
/Users/ryan/.rvm/rubies/ruby-1.9.3-p0/lib/ruby/1.9.1/net/http.rb:1307:in `send_entity'
/Users/ryan/.rvm/rubies/ruby-1.9.3-p0/lib/ruby/1.9.1/net/http.rb:1096:in`post'
paypal_adaptive (0.2.6) lib/paypal_adaptive/request.rb:88:in `post'
