### PR TITLE
CorrelationId added now can be accessible as return_correlationid.to_s

### DIFF
--- a/lib/paypal_adaptive/response.rb
+++ b/lib/paypal_adaptive/response.rb
@@ -12,8 +12,8 @@ module PaypalAdaptive
         !(self['paymentExecStatus'].to_s =~ /^ERROR$/i)
     end
     
-    def correlationid
-       return self['responseEnvelope']['ack'].to_s
+    def return_correlationid
+       return self['responseEnvelope']['correlationId'].to_s
     end
     
     def errors


### PR DESCRIPTION
Correlation ID now can be accessible as pay_request.pay(data).return_correlationid.to_s
