### PR TITLE
more information regarding embedded payments

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -76,6 +76,11 @@ Additionally, you can make calls to Paypal Adaptive's other APIs:
 
 Input is just a Hash just like the pay method. Refer to the Paypal manual for more details.
 
+### Using the embedded payment flow
+Instead of redirecting to the url from ```redirect_to pay_response.approve_paypal_payment_url``` you can generate the action url for your
+form by using ```pay_response.approve_paypal_payment_url 'MY TYPE' ``` The two types that are supported for embedded payment are 'light' and 'mini'
+More information about these types can be found here https://cms.paypal.com/us/cgi-bin/?cmd=_render-content&content_ID=developer/e_howto_api_APIntro
+
 ### Certificate validation
 You can set the location of the .pem file you wish to use for SSL certificate validation in paypal_adaptive.yml
 for each environment, e.g.:


### PR DESCRIPTION
I'm actually working on a pull that breaks the embedded url out of PaypalAdaptive::Response#approve_paypal_payment_url into it's own method. It may be a little to controversial though since there is nothing functionally new and it's not backwards compatible for paypal_adaptive users sending the light/mini types to approve_paypal_payment_url. I'll send it anyways and you can make the decision :P Also created a rails helper for generating the embedded payments form automagically.
