### PR TITLE
Fix for bug in mreinsch's config handling code

### DIFF
--- a/lib/paypal_adaptive/response.rb
+++ b/lib/paypal_adaptive/response.rb
@@ -1,7 +1,7 @@
 module PaypalAdaptive
   class Response < Hash    
     def initialize(response, env=nil)
-      config = PaypalAdaptive::Config.new(env)
+      config = PaypalAdaptive.config(env)
       @paypal_base_url = config.paypal_base_url
       
       self.merge!(response)


### PR DESCRIPTION
Hi Tommy,

This is a small fix to the new Rails config handling code that mreinsch submitted in December. It ensures that the Rails config is used not only for Requests, but also for Responses.

Thanks for the gem,
Dave
