### PR TITLE
Errors related to using Paypal API with certificate instead of signature

### DIFF
--- a/lib/paypal_adaptive/config.rb
+++ b/lib/paypal_adaptive/config.rb
@@ -16,7 +16,7 @@ module PaypalAdaptive
     } unless defined? API_BASE_URL_MAPPING
 
     attr_accessor :paypal_base_url, :api_base_url, :headers, :ssl_cert_path, :ssl_cert_file
-  
+
     def initialize(env=nil, config_override={})
       config = YAML.load(ERB.new(File.new(config_filepath).read).result)[env]
       raise "Could not load settings from config file" unless config
@@ -31,17 +31,17 @@ module PaypalAdaptive
         @ssl_cert_file = nil
         @paypal_base_url = PAYPAL_BASE_URL_MAPPING[pp_env]
         @api_base_url = API_BASE_URL_MAPPING[pp_env]
-        
+
         # http.rb requires headers to be strings. Protect against ints in paypal_adaptive.yml
         config.update(config){ |key,v| v.to_s }
         @headers = {
           "X-PAYPAL-SECURITY-USERID" => config['username'],
           "X-PAYPAL-SECURITY-PASSWORD" => config['password'],
-          "X-PAYPAL-SECURITY-SIGNATURE" => config['signature'],
           "X-PAYPAL-APPLICATION-ID" => config['application_id'],
           "X-PAYPAL-REQUEST-DATA-FORMAT" => "JSON",
           "X-PAYPAL-RESPONSE-DATA-FORMAT" => "JSON"
         }
+        @headers.merge!({"X-PAYPAL-SECURITY-SIGNATURE" => config['signature']}) if config['signature']
 
         if config['ssl_cert_file'] && config['ssl_cert_file'].length > 0
           @ssl_cert_file = config['ssl_cert_file']

--- a/lib/paypal_adaptive/ipn_notification.rb
+++ b/lib/paypal_adaptive/ipn_notification.rb
@@ -4,14 +4,14 @@ require 'json'
 
 module PaypalAdaptive
   class IpnNotification
-    
+
     def initialize(env=nil)
       config = PaypalAdaptive.config(env)
       @paypal_base_url = config.paypal_base_url
       @ssl_cert_path = config.ssl_cert_path
       @ssl_cert_file = config.ssl_cert_file
     end
-    
+
     def send_back(data)
       data = "cmd=_notify-validate&#{data}"
       url = URI.parse @paypal_base_url
@@ -19,17 +19,22 @@ module PaypalAdaptive
       http.use_ssl = true
       http.verify_mode = OpenSSL::SSL::VERIFY_PEER
       http.ca_path = @ssl_cert_path unless @ssl_cert_path.nil?
-      http.ca_file = @ssl_cert_file unless @ssl_cert_file.nil?
-      
+
+      if @ssl_cert_file
+        cert = File.read(@ssl_cert_file)
+        http.cert = OpenSSL::X509::Certificate.new(cert)
+        http.key = OpenSSL::PKey::RSA.new(cert)
+      end
+
       path = "#{@paypal_base_url}/cgi-bin/webscr"
       response_data = http.post(path, data).body
-      
+
       @verified = response_data == "VERIFIED"
     end
-    
+
     def verified?
       @verified
     end
-    
+
   end
 end

--- a/lib/paypal_adaptive/request.rb
+++ b/lib/paypal_adaptive/request.rb
@@ -82,8 +82,13 @@ module PaypalAdaptive
       http = Net::HTTP.new(url.host, 443)
       http.use_ssl = true
       http.verify_mode = OpenSSL::SSL::VERIFY_PEER
+
+      if @ssl_cert_file
+        cert = File.read(@ssl_cert_file)
+        http.cert = OpenSSL::X509::Certificate.new(cert)
+        http.key = OpenSSL::PKey::RSA.new(cert)
+      end
       http.ca_path = @ssl_cert_path unless @ssl_cert_path.nil?
-      http.ca_file = @ssl_cert_file unless @ssl_cert_file.nil?
 
       response_data = http.post(path, api_request_data, @headers).body
 


### PR DESCRIPTION
2 issues that are related.
1. Signature is included in the headers regardless if it is present or not. When you are using a certificate there is no signature and this leads to an error inside net/http#post. 
   
   ```
   NoMethodError (undefined method `strip' for nil:NilClass):
             activesupport (3.1.3) lib/active_support/whiny_nil.rb:48:in `method_missing'
             /opt/ruby-1.9.3-p0/lib/ruby/1.9.1/net/http.rb:1435:in `block in initialize_http_h
   ```
   
   eader'
2. The line 
       http.ca_file = @ssl_cert_file unless @ssl_cert_file.nil?
   Doesn't work for me with Rails 3/Ruby 1.9.3 p0. Implemented an alternate method of setting the SSL cert that should be used.
