### PR TITLE
ssl_cert_file is not the same as cert or key, use ca_file

### DIFF
--- a/lib/paypal_adaptive/request.rb
+++ b/lib/paypal_adaptive/request.rb
@@ -88,9 +88,10 @@ module PaypalAdaptive
       http.verify_mode = OpenSSL::SSL::VERIFY_PEER
 
       if @ssl_cert_file
-        cert = File.read(@ssl_cert_file)
-        http.cert = OpenSSL::X509::Certificate.new(cert)
-        http.key = OpenSSL::PKey::RSA.new(cert)
+        #cert = File.read(@ssl_cert_file)
+        #http.cert = OpenSSL::X509::Certificate.new(cert)
+        #http.key = OpenSSL::PKey::RSA.new(cert)
+        http.ca_file = @ssl_cert_file
       end
       http.ca_path = @ssl_cert_path unless @ssl_cert_path.nil?
 


### PR DESCRIPTION
A ca_file is not the same as a cert or key. This commit only sets `http.ca_file = @ssl_cert_file` and ignores `http.cert` and `http.key`. Depending on the format of your ssl_cert_file, it may throw errors if you try to parse it as a X509 Certificate or RSA key (it did for me).

You should use different config keys (e.g. `ssl_509cert` and `ssl_key_file`) if you'd like users to set the key or cert file specifically. Neither worked for me, so I didn't bother.

Check http://martinottenwaelter.fr/2010/12/ruby19-and-the-ssl-error/ for an example of the two different ways he solved SSL certificate verification errors. You already support `http.ca_path = @ssl_cert_path` (even though you don't demonstrate it in your sample config file). This commit adds support for `http.ca_file` as well.

I tested this on a small EC2 instance running the Amazon AMI with Ruby v1.8.7p357. The `ca_file` is `/etc/ssl/certs/ca-bundle.crt`. `ca_path` didn't work. The blog link indicates `ca_path` may only work on Ubuntu.
