### PR TITLE
Fix spelling in request#rescue_error_message so response#success? doesn't raise a Nil exception

### DIFF
--- a/lib/paypal_adaptive/request.rb
+++ b/lib/paypal_adaptive/request.rb
@@ -76,7 +76,7 @@ module PaypalAdaptive
     end
 
     def rescue_error_message(e, message = nil)
-      {"responseEvelope" => {"ack" => "Failure"}, "error" => [{"message" => (message ||= e)}]}
+      {"responseEnvelope" => {"ack" => "Failure"}, "error" => [{"message" => (message ||= e)}]}
     end
 
     def post(data, path)


### PR DESCRIPTION
This fixes issue #48
