### PR TITLE
No more way to set the api certificate since ssl_cert_file config is now used to set CA Authority.

### DIFF
--- a/lib/paypal_adaptive/config.rb
+++ b/lib/paypal_adaptive/config.rb
@@ -15,7 +15,7 @@ module PaypalAdaptive
       :beta_sandbox => "https://svcs.beta-sandbox.paypal.com"
     } unless defined? API_BASE_URL_MAPPING
 
-    attr_accessor :paypal_base_url, :api_base_url, :headers, :ssl_cert_path, :ssl_cert_file
+    attr_accessor :paypal_base_url, :api_base_url, :headers, :ssl_cert_path, :ssl_cert_file, :api_cert_file
 
     def initialize(env=nil, config_override={})
       config = YAML.load(ERB.new(File.new(config_filepath).read).result)[env]
@@ -29,6 +29,7 @@ module PaypalAdaptive
 
         @ssl_cert_path = nil
         @ssl_cert_file = nil
+        @api_cert_file = nil
         @paypal_base_url = PAYPAL_BASE_URL_MAPPING[pp_env]
         @api_base_url = API_BASE_URL_MAPPING[pp_env]
 
@@ -42,8 +43,9 @@ module PaypalAdaptive
           "X-PAYPAL-RESPONSE-DATA-FORMAT" => "JSON"
         }
         @headers.merge!({"X-PAYPAL-SECURITY-SIGNATURE" => config['signature']}) if config['signature']
-
+        @ssl_cert_path = config['ssl_cert_path'] unless config['ssl_cert_path'].blank?
         @ssl_cert_file = config['ssl_cert_file'] unless config['ssl_cert_file'].blank?
+        @api_cert_file = config['api_cert_file'] unless config['api_cert_file'].blank?
       end
     end
 

--- a/lib/paypal_adaptive/ipn_notification.rb
+++ b/lib/paypal_adaptive/ipn_notification.rb
@@ -10,6 +10,7 @@ module PaypalAdaptive
       @paypal_base_url = config.paypal_base_url
       @ssl_cert_path = config.ssl_cert_path
       @ssl_cert_file = config.ssl_cert_file
+      @api_cert_file = config.api_cert_file
     end
 
     def send_back(data)
@@ -20,12 +21,13 @@ module PaypalAdaptive
       http.verify_mode = OpenSSL::SSL::VERIFY_PEER
       http.ca_path = @ssl_cert_path unless @ssl_cert_path.nil?
 
-      if @ssl_cert_file
-        # cert = File.read(@ssl_cert_file)
-        # http.cert = OpenSSL::X509::Certificate.new(cert)
-        # http.key = OpenSSL::PKey::RSA.new(cert)
-        http.ca_file = @ssl_cert_file
+      if @api_cert_file
+        cert = File.read(@api_cert_file)
+        http.cert = OpenSSL::X509::Certificate.new(cert)
+        http.key = OpenSSL::PKey::RSA.new(cert)
       end
+      http.ca_path = @ssl_cert_path unless @ssl_cert_path.blank?
+      http.ca_file = @ssl_cert_file unless @ssl_cert_file.blank?
 
       path = "#{@paypal_base_url}/cgi-bin/webscr"
       response_data = http.post(path, data).body

--- a/lib/paypal_adaptive/request.rb
+++ b/lib/paypal_adaptive/request.rb
@@ -14,6 +14,7 @@ module PaypalAdaptive
       @headers = config.headers
       @ssl_cert_path = config.ssl_cert_path
       @ssl_cert_file = config.ssl_cert_file
+      @api_cert_file = config.api_cert_file
     end
 
     def validate
@@ -91,13 +92,13 @@ module PaypalAdaptive
       http.use_ssl = true
       http.verify_mode = OpenSSL::SSL::VERIFY_PEER
 
-      if @ssl_cert_file
-        #cert = File.read(@ssl_cert_file)
-        #http.cert = OpenSSL::X509::Certificate.new(cert)
-        #http.key = OpenSSL::PKey::RSA.new(cert)
-        http.ca_file = @ssl_cert_file
+      if @api_cert_file
+        cert = File.read(@api_cert_file)
+        http.cert = OpenSSL::X509::Certificate.new(cert)
+        http.key = OpenSSL::PKey::RSA.new(cert)
       end
-      http.ca_path = @ssl_cert_path unless @ssl_cert_path.nil?
+      http.ca_path = @ssl_cert_path unless @ssl_cert_path.blank?
+      http.ca_file = @ssl_cert_file unless @ssl_cert_file.blank?
 
       begin
         response_data = http.post(path, api_request_data, @headers)


### PR DESCRIPTION
...file config is used to set the CA authority. Apps that are using api certificate instead of signature has no way to set the api certiciate, since ssl_cert_file is now used to set the CA authority. Made a new config, api_cert_file to be able to set the paypal api certificate file. 
