### PR TITLE
Dynamic verify mode based on Paypal environment

### DIFF
--- a/lib/paypal_adaptive/config.rb
+++ b/lib/paypal_adaptive/config.rb
@@ -15,7 +15,8 @@ module PaypalAdaptive
       :beta_sandbox => "https://svcs.beta-sandbox.paypal.com"
     } unless defined? API_BASE_URL_MAPPING
 
-    attr_accessor :paypal_base_url, :api_base_url, :headers, :ssl_cert_path, :ssl_cert_file, :api_cert_file
+    attr_accessor :paypal_base_url, :api_base_url, :headers, :ssl_cert_path, :ssl_cert_file, :api_cert_file,
+      :verify_mode
 
     def initialize(env=nil, config_override={})
       config = YAML.load(ERB.new(File.new(config_filepath).read).result)[env]
@@ -48,6 +49,11 @@ module PaypalAdaptive
         @ssl_cert_path = config['ssl_cert_path'] unless config['ssl_cert_path'].blank?
         @ssl_cert_file = config['ssl_cert_file'] unless config['ssl_cert_file'].blank?
         @api_cert_file = config['api_cert_file'] unless config['api_cert_file'].blank?
+        @verify_mode = if pp_env == :sandbox
+          OpenSSL::SSL::VERIFY_NONE
+        else
+          OpenSSL::SSL::VERIFY_PEER
+        end
       end
     end
 

--- a/lib/paypal_adaptive/ipn_notification.rb
+++ b/lib/paypal_adaptive/ipn_notification.rb
@@ -11,12 +11,7 @@ module PaypalAdaptive
       @ssl_cert_path = config.ssl_cert_path
       @ssl_cert_file = config.ssl_cert_file
       @api_cert_file = config.api_cert_file
-      @paypal_env = config['environment'].to_sym
-      @verify_mode = if @paypal_env == :sandbox
-        OpenSSL::SSL::VERIFY_NONE
-      else
-        OpenSSL::SSL::VERIFY_PEER
-      end
+      @verify_mode = config.verify_mode
     end
 
     def send_back(data)

--- a/lib/paypal_adaptive/request.rb
+++ b/lib/paypal_adaptive/request.rb
@@ -15,6 +15,7 @@ module PaypalAdaptive
       @ssl_cert_path = config.ssl_cert_path
       @ssl_cert_file = config.ssl_cert_file
       @api_cert_file = config.api_cert_file
+      @verify_mode = config.verify_mode
     end
 
     def validate
@@ -90,7 +91,7 @@ module PaypalAdaptive
       url = URI.parse @api_base_url
       http = Net::HTTP.new(url.host, 443)
       http.use_ssl = true
-      http.verify_mode = OpenSSL::SSL::VERIFY_PEER
+      http.verify_mode = @verify_mode
 
       if @api_cert_file
         cert = File.read(@api_cert_file)


### PR DESCRIPTION
We have encountered **certificate verify failed** error when using paypal_adaptive with the Paypal Sandbox. However, the error doesn't occur when connecting to the production Paypal URL. The fix dynamically changes verify mode depending on the Paypal environment. When in Sandbox env, verify mode is OpenSSL::SSL::VERIFY_NONE. Else, OpenSSL::SSL::VERIFY_PEER, which is the previously hardcoded value.
