### PR TITLE
include more details in error

### DIFF
--- a/paypal_adaptive.gemspec
+++ b/paypal_adaptive.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |s|
   s.add_dependency("jsonschema", "~>2.0.0")
   s.add_development_dependency("rake")
   s.add_development_dependency("activesupport", "~> 3.2.0")
+  s.add_development_dependency("webmock")
 
   s.rubyforge_project = "paypal_adaptive"
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,3 +7,6 @@ require "json"
 require "jsonschema"
 require 'paypal_adaptive'
 require 'active_support/core_ext/string'
+require 'webmock/minitest'
+
+WebMock.allow_net_connect!

--- a/test/unit/request_test.rb
+++ b/test/unit/request_test.rb
@@ -12,16 +12,27 @@ class RequestTest < Test::Unit::TestCase
     assert_instance_of Hash, response
   end
 
-  def test_post_should_return_hash_when_request_is_invalid
+  def test_post_should_return_error_message_when_request_is_invalid
     request = PaypalAdaptive::Request.new('test')
     response = request.post({:data => true}, '/some-random-url')
     assert_instance_of Hash, response
+    assert_equal "Connection Reset. Request invalid URL.", response["error"][0]["message"]
   end
 
-  def test_post_shoudl_return_error_message_when_request_is_invalid
+  def test_post_should_return_error_details_when_response_is_invalid
+    WebMock.disable_net_connect!
+    stub_request(:post, "https://svcs.sandbox.paypal.com/some-random-url").
+      to_return(:status => [500, "Internal Server Error"], :body => "Something went wrong")
     request = PaypalAdaptive::Request.new('test')
     response = request.post({:data => true}, '/some-random-url')
-    assert_not_nil response["error"][0]["message"]
+    assert_instance_of Hash, response
+    error = response["error"].first
+    assert_instance_of Hash, error
+    assert_equal "Response is not in JSON format.", error["message"]
+    assert_equal "500", error["details"]["httpCode"]
+    assert_equal "Internal Server Error", error["details"]["httpMessage"]
+    assert_equal "Something went wrong", error["details"]["httpBody"]
+  ensure
+    WebMock.allow_net_connect!
   end
-  
 end


### PR DESCRIPTION
In case a HTTP request doesn't return valid JSON, it is better to include some more details from the response in the fake response hash.

Also combined a tests which didn't make much sense to test independently.
