### PR TITLE
get_funding_plans method

### DIFF
--- a/lib/paypal_adaptive/request.rb
+++ b/lib/paypal_adaptive/request.rb
@@ -74,6 +74,10 @@ module PaypalAdaptive
     def get_verified_status(data)
       wrap_post(data, "/AdaptiveAccounts/GetVerifiedStatus")
     end
+    
+    def get_funding_plans(data)
+      wrap_post(data, "/AdaptivePayments/GetFundingPlans")
+    end
 
     def wrap_post(data, path)
       raise NoDataError unless data


### PR DESCRIPTION
Added a new request method for getting funding plan(s) called get_funding_plans. GetFundingPlans is part of the Paypal Adaptive Payments API.
