### PR TITLE
Ensure POST response is not decompressed under Ruby 2.0

### DIFF
--- a/lib/paypal_adaptive/request.rb
+++ b/lib/paypal_adaptive/request.rb
@@ -12,6 +12,7 @@ module PaypalAdaptive
       config = PaypalAdaptive.config(env)
       @api_base_url = config.api_base_url
       @headers = config.headers
+      @headers['Accept-Encoding'] = 'identity'
       @ssl_cert_path = config.ssl_cert_path
       @ssl_cert_file = config.ssl_cert_file
       @api_cert_file = config.api_cert_file


### PR DESCRIPTION
Fixes the issue mentioned at https://github.com/tc/paypal_adaptive/issues/75#issuecomment-44062502. Analogous to https://github.com/tc/paypal_adaptive/pull/76

This has been tested under Rubies 1.9.3, 2.0.0, 2.1.0.
