### PR TITLE
Remove dependency on blank?

### DIFF
--- a/lib/paypal_adaptive/config.rb
+++ b/lib/paypal_adaptive/config.rb
@@ -46,9 +46,9 @@ module PaypalAdaptive
           "X-PAYPAL-RESPONSE-DATA-FORMAT" => "JSON"
         }
         @headers.merge!({"X-PAYPAL-SECURITY-SIGNATURE" => config['signature']}) if config['signature']
-        @ssl_cert_path = config['ssl_cert_path'] unless config['ssl_cert_path'].blank?
-        @ssl_cert_file = config['ssl_cert_file'] unless config['ssl_cert_file'].blank?
-        @api_cert_file = config['api_cert_file'] unless config['api_cert_file'].blank?
+        @ssl_cert_path = config['ssl_cert_path'] unless config['ssl_cert_path'].nil? || config['ssl_cert_path'].length == 0
+        @ssl_cert_file = config['ssl_cert_file'] unless config['ssl_cert_file'].nil? || config['ssl_cert_file'].length == 0
+        @api_cert_file = config['api_cert_file'] unless config['api_cert_file'].nil? || config['api_cert_file'].length == 0
         @verify_mode = if pp_env == :sandbox
           OpenSSL::SSL::VERIFY_NONE
         else

--- a/lib/paypal_adaptive/ipn_notification.rb
+++ b/lib/paypal_adaptive/ipn_notification.rb
@@ -29,8 +29,8 @@ module PaypalAdaptive
         http.cert = OpenSSL::X509::Certificate.new(cert)
         http.key = OpenSSL::PKey::RSA.new(cert)
       end
-      http.ca_path = @ssl_cert_path unless @ssl_cert_path.blank?
-      http.ca_file = @ssl_cert_file unless @ssl_cert_file.blank?
+      http.ca_path = @ssl_cert_path unless @ssl_cert_path.nil? || @ssl_cert_path.length == 0
+      http.ca_file = @ssl_cert_file unless @ssl_cert_file.nil? || @ssl_cert_file.length == 0
 
       req = Net::HTTP::Post.new(url.request_uri)
       # we don't want #set_form_data to create a hash and get our

--- a/lib/paypal_adaptive/request.rb
+++ b/lib/paypal_adaptive/request.rb
@@ -110,8 +110,8 @@ module PaypalAdaptive
         http.cert = OpenSSL::X509::Certificate.new(cert)
         http.key = OpenSSL::PKey::RSA.new(cert)
       end
-      http.ca_path = @ssl_cert_path unless @ssl_cert_path.blank?
-      http.ca_file = @ssl_cert_file unless @ssl_cert_file.blank?
+      http.ca_path = @ssl_cert_path unless @ssl_cert_path.nil? || @ssl_cert_path.length == 0
+      http.ca_file = @ssl_cert_file unless @ssl_cert_file.nil? || @ssl_cert_file.length == 0
 
       begin
         response_data = http.post(path, api_request_data, @headers)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,7 +6,6 @@ require "test/unit"
 require "json"
 require "jsonschema"
 require 'paypal_adaptive'
-require 'active_support/core_ext/string'
 require 'webmock/minitest'
 
 WebMock.allow_net_connect!

--- a/test/unit/config_test.rb
+++ b/test/unit/config_test.rb
@@ -7,6 +7,12 @@ class ConfigTest < Test::Unit::TestCase
     assert_equal nil, @config.ssl_cert_path
   end
 
+  def test_blank_ssl_cert_file
+    @config = PaypalAdaptive::Config.new("test", { "ssl_cert_file" => "" })
+    assert_equal nil, @config.ssl_cert_file
+    assert_equal nil, @config.ssl_cert_path
+  end
+
   def test_erb_tags
     ENV['paypal.username'] = 'account@email.com'
     ENV['paypal.password'] = 's3krit'


### PR DESCRIPTION
This PR removes the dependency on Rails' blank? method so it can be called from Ruby.

The test suite doesn't appear to be clean, but as a minimum I did not add any additional failures or errors from this original set:
```
30 tests, 31 assertions, 13 failures, 1 errors, 0 pendings, 0 omissions, 0 notifications
```
