### PR TITLE
remove json dependency

### DIFF
--- a/paypal_adaptive.gemspec
+++ b/paypal_adaptive.gemspec
@@ -12,7 +12,6 @@ Gem::Specification.new do |s|
   s.summary     = "Lightweight wrapper for Paypal's Adaptive Payments API"
   s.description = "Lightweight wrapper for Paypal's Adaptive Payments API"
 
-  s.add_dependency("json", "~>1.0")
   s.add_dependency("jsonschema", "~>2.0.0")
   s.add_development_dependency("rake")
   s.add_development_dependency("webmock")


### PR DESCRIPTION
The json 1.0 dependency is getting in the way with a lot of other gems and in my case forced an old version of paypal_adaptive (that didnt have the 1.0 dep) which does not work with the current paypal API, breaking my application.

It is now considered bad form to directly depend on json (see http://www.mikeperham.com/2016/02/09/kill-your-dependencies/).

This PR removes the dependency and lets ruby Just Deal With It.