### PR TITLE
[Release] Bumping version and changelog

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -96,6 +96,9 @@ for each environment, e.g.:
 The api_cert_file should point to your cert_key_pem.txt that is downloaded through the paypal developer interface. It will contain a section that specifies the RSA private key and another section that specifies a certificate. If this is left empty, paypal_adaptive will attempt to use the signature method of validation with PayPal, so your signature config must not be nil.
 
 ## Changelog
+0.3.11
+Remove `json` from dependencies
+
 0.3.10
 Remove Rails dependent gems thanks @ rchekaluk
 

--- a/lib/paypal_adaptive/version.rb
+++ b/lib/paypal_adaptive/version.rb
@@ -1,4 +1,4 @@
 module PaypalAdaptive
-  VERSION = "0.3.10"
+  VERSION = "0.3.11"
 end
 


### PR DESCRIPTION
The last commit on master removes the `json` dependency but there has been no release since this change. 
Would it be possible to release the 0.3.11 to make the change official ? 
Thanks a lot and thank you for the work on the gem ! 

### description
Change version number to `0.3.11` and add entry to the changelog.